### PR TITLE
Optimize creation of diagrams in their editors.

### DIFF
--- a/olca-app/src/org/openlca/app/editors/graphical/GraphEditor.java
+++ b/olca-app/src/org/openlca/app/editors/graphical/GraphEditor.java
@@ -68,6 +68,7 @@ public class GraphEditor extends GraphicalEditor {
 	// TODO: save this in the same way as the layout is currently stored
 	public final GraphConfig config = new GraphConfig();
 	private final GraphFactory graphFactory = new GraphFactory(this);
+	public boolean wasFocus = false;
 
 	public GraphEditor(ProductSystemEditor editor) {
 		this.systemEditor = editor;
@@ -320,8 +321,9 @@ public class GraphEditor extends GraphicalEditor {
 	@Override
 	protected void setInput(IEditorInput input) {
 		super.setInput(input);
-		var array = GraphFile.getLayouts(this);
-		setModel(getGraphFactory().createGraph(this, array));
+		// The model is initialized with an empty graph so that it is only created
+		// when the model graph page is open (see ProductSystemEditor).
+		setModel(new Graph(this));
 	}
 
 	public void setDirty() {
@@ -397,9 +399,13 @@ public class GraphEditor extends GraphicalEditor {
 		return systemEditor;
 	}
 
-	public void focusOnReferenceNode() {
+	public boolean focusOnReferenceNode() {
 		var action = getActionRegistry().getAction(ActionIds.FOCUS);
-		if (action.isEnabled()) action.run();
+		if (action.isEnabled()) {
+			action.run();
+			return true;
+		}
+		else return false;
 	}
 
 }

--- a/olca-app/src/org/openlca/app/editors/graphical/layouts/Layout.java
+++ b/olca-app/src/org/openlca/app/editors/graphical/layouts/Layout.java
@@ -45,4 +45,12 @@ public class Layout extends GraphLayout {
 		return null;
 	}
 
+	@Override
+	protected void focusOnStart() {
+		var editor = graph.editor;
+		if (!editor.wasFocus) {
+			editor.wasFocus = editor.focusOnReferenceNode();
+		}
+	}
+
 }

--- a/olca-app/src/org/openlca/app/editors/systems/ProductSystemEditor.java
+++ b/olca-app/src/org/openlca/app/editors/systems/ProductSystemEditor.java
@@ -2,9 +2,11 @@ package org.openlca.app.editors.systems;
 
 import java.util.concurrent.atomic.AtomicReference;
 
+import org.eclipse.gef.GraphicalViewer;
 import org.eclipse.jface.dialogs.IPageChangedListener;
 import org.openlca.app.M;
 import org.openlca.app.editors.ModelEditor;
+import org.openlca.app.editors.graphical.GraphFile;
 import org.openlca.app.editors.graphical.GraphicalEditorInput;
 import org.openlca.app.editors.graphical.GraphEditor;
 import org.openlca.app.util.ErrorReporter;
@@ -30,27 +32,37 @@ public class ProductSystemEditor extends ModelEditor<ProductSystem> {
 			var graphEditor = new GraphEditor(this);
 			int gIdx = addPage(graphEditor, gInput);
 			setPageText(gIdx, M.ModelGraph);
-			// Add a page listener to focus the graph on the reference node when it is
-			// activated the first time.
-			var graphInit = new AtomicReference<IPageChangedListener>();
-			IPageChangedListener fn = e -> {
-				if (e.getSelectedPage() != graphEditor)
-					return;
-				var listener = graphInit.get();
-				if (listener == null)
-					return;
-				graphEditor.focusOnReferenceNode();
-				removePageChangedListener(listener);
-				graphInit.set(null);
-			};
-			graphInit.set(fn);
-			addPageChangedListener(fn);
+			// Add a page listener to set the graph when it is activated the first
+			// time.
+			setGraphPageListener(graphEditor);
 
 			addPage(new StatisticsPage(this));
 			addCommentPage();
 		} catch (Exception e) {
 			ErrorReporter.on("failed to add page", e);
 		}
+	}
+
+	private void setGraphPageListener(GraphEditor graphEditor) {
+		var graphInit = new AtomicReference<IPageChangedListener>();
+		IPageChangedListener fn = e -> {
+			if (e.getSelectedPage() != graphEditor)
+				return;
+			var listener = graphInit.get();
+			if (listener == null)
+				return;
+			var array = GraphFile.getLayouts(graphEditor);
+			var diagram = graphEditor.getGraphFactory()
+					.createGraph(graphEditor, array);
+			graphEditor.setModel(diagram);
+			var viewer = (GraphicalViewer) graphEditor
+					.getAdapter(GraphicalViewer.class);
+			viewer.setContents(diagram);
+			removePageChangedListener(listener);
+			graphInit.set(null);
+		};
+		graphInit.set(fn);
+		addPageChangedListener(fn);
 	}
 
 }

--- a/olca-app/src/org/openlca/app/results/analysis/sankey/SankeyEditor.java
+++ b/olca-app/src/org/openlca/app/results/analysis/sankey/SankeyEditor.java
@@ -60,6 +60,7 @@ public class SankeyEditor extends GraphicalEditor {
 	public final SankeyConfig config;
 	private Diagram diagram;
 	private Sankey<?> sankey;
+	public boolean wasFocus = false;
 
 	public SankeyEditor(ResultEditor parent) {
 		this.resultEditor = parent;
@@ -136,7 +137,9 @@ public class SankeyEditor extends GraphicalEditor {
 	@Override
 	protected void setInput(IEditorInput input) {
 		super.setInput(input);
-		setModel(getSankeyFactory().createDiagram());
+		// The model is initialized with an empty diagram so that it is only created
+		// when the SankeyDiagram page is open (see ResultEditor).
+		setModel(new Diagram(this, config.orientation()));
 	}
 
 	/**
@@ -286,9 +289,13 @@ public class SankeyEditor extends GraphicalEditor {
 		return sankey;
 	}
 
-	public void focusOnReferenceNode() {
+	public boolean focusOnReferenceNode() {
 		var action = getActionRegistry().getAction(ActionIds.FOCUS);
-		if (action.isEnabled()) action.run();
+		if (action.isEnabled()) {
+			action.run();
+			return true;
+		}
+		else return false;
 	}
 
 }

--- a/olca-app/src/org/openlca/app/results/analysis/sankey/actions/FocusAction.java
+++ b/olca-app/src/org/openlca/app/results/analysis/sankey/actions/FocusAction.java
@@ -29,7 +29,8 @@ public class FocusAction extends WorkbenchPartAction {
 			return false;
 		viewer = (GraphicalViewer) editor.getAdapter(GraphicalViewer.class);
 		return viewer != null && editor.getModel() != null
-			&& editor.getModel().getNode(editor.getSankey().root) != null;
+				&& editor.getSankey() != null
+				&& editor.getModel().getNode(editor.getSankey().root) != null;
 	}
 
 	@Override

--- a/olca-app/src/org/openlca/app/results/analysis/sankey/layouts/SankeyLayout.java
+++ b/olca-app/src/org/openlca/app/results/analysis/sankey/layouts/SankeyLayout.java
@@ -52,4 +52,13 @@ public class SankeyLayout extends GraphLayout {
 		}
 		return null;
 	}
+
+	@Override
+	protected void focusOnStart() {
+		var editor = diagram.editor;
+		if (!editor.wasFocus) {
+			editor.wasFocus = editor.focusOnReferenceNode();
+		}
+	}
+
 }

--- a/olca-app/src/org/openlca/app/tools/graphics/layouts/GraphLayout.java
+++ b/olca-app/src/org/openlca/app/tools/graphics/layouts/GraphLayout.java
@@ -31,6 +31,11 @@ public abstract class GraphLayout extends FreeformLayout implements LayoutInterf
 	/** A map keeping track of nodes laid out by the TreeLayout. */
 	final Map<Component, Vertex> mapNodeToVertex = new HashMap<>();
 	private IFigure parentFigure;
+	/**
+	 * Figures are usually laid out in two times as children are laid out first.
+	 * This flag allows to execute tasks after the pre-layout.
+	 */
+	private boolean preLayout = false;
 
 	public GraphLayout(int orientation) {
 		this.orientation = orientation;
@@ -63,7 +68,11 @@ public abstract class GraphLayout extends FreeformLayout implements LayoutInterf
 				figure.setBounds(bounds.getTranslated(offset));
 			}
 		}
+		if (preLayout) focusOnStart();
+		if (!preLayout) preLayout = true;
 	}
+
+	protected abstract void focusOnStart();
 
 	private Point calculateLocation(Figure figure, Rectangle constraint) {
 		// Set the location to the TreeLayout location if the figure has not been


### PR DESCRIPTION
 - For both the Sankey Diagram and the Model Graph:
  - Editor inputs are initialized with an empty model.
  - The complete model is constructed when the user click on their respective pages.
  - Initial focus execution is now operated after the pre-layout via the GraphLayout class.