### PR TITLE
Credits file generator

### DIFF
--- a/olca-app-build/credits/about_template.html
+++ b/olca-app-build/credits/about_template.html
@@ -6,7 +6,7 @@
     <title>About openLCA</title>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
   </head>
-  <style>html,body{width: 100%;margin: 0;padding: 0;} html{position: relative;min-height: 100%;} .container{max-width: 700px;margin: 0;padding: 0;} .heading{font-size: 28px;text-align: center;margin: 15px;} .block-container{margin: auto;width: 70%;display: flex;flex-direction: column;} .inner-block-container{width: 100%;margin-bottom: 10px;} .block{width: 100%;display: flex;flex-direction: row;justify-content: space-between;background-color: #d7d7d7;border-radius: 5px;font-size: 12px;} .pointer{cursor: pointer;} .links-blk{display: flex;flex-direction: row;} .licence-details{padding: 2px 8px;font-size: 10px;} .mr-pd{padding: 5px;} .hide{display: none;}</style>
+  <style>html,body{width: 100%;margin: 0;padding: 0;} html{position: relative;min-height: 100%;} .container{max-width: 700px;margin: 0 auto;padding: 0;} .heading{font-size: 28px;text-align: center;margin: 15px;} .block-container{margin: auto;width: 70%;display: flex;flex-direction: column;} .inner-block-container{width: 100%;margin-bottom: 10px;} .block{width: 100%;display: flex;flex-direction: row;justify-content: space-between;background-color: #d7d7d7;border-radius: 5px;font-size: 12px;} .pointer{cursor: pointer;} .links-blk{display: flex;flex-direction: row;} .licence-details{padding: 2px 8px;font-size: 10px;} .mr-pd{padding: 5px;} .hide{display: none;}</style>
   <body>
     <div class="container">
       <div class="heading"><span>Credits</span></div>

--- a/olca-app-build/credits/about_template.html
+++ b/olca-app-build/credits/about_template.html
@@ -1,43 +1,72 @@
 <!DOCTYPE html>
 <html>
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <title>About openLCA</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+  </head>
+  <style>html,body{width: 100%;margin: 0;padding: 0;} html{position: relative;min-height: 100%;} .container{max-width: 700px;margin: 0;padding: 0;} .heading{font-size: 28px;text-align: center;margin: 15px;} .block-container{margin: auto;width: 70%;display: flex;flex-direction: column;} .inner-block-container{width: 100%;margin-bottom: 10px;} .block{width: 100%;display: flex;flex-direction: row;justify-content: space-between;background-color: #d7d7d7;border-radius: 5px;font-size: 12px;} .pointer{cursor: pointer;} .links-blk{display: flex;flex-direction: row;} .licence-details{padding: 2px 8px;font-size: 10px;} .mr-pd{padding: 5px;} .hide{display: none;}</style>
+  <body>
+    <div class="container">
+      <div class="heading"><span>Credits</span></div>
 
-<head>
-  <meta charset='utf-8'>
-  <meta http-equiv='X-UA-Compatible' content='IE=edge'>
-  <title>About openLCA</title>
-  <meta name='viewport' content='width=device-width, initial-scale=1'>
-</head>
+      <p>
+        The openLCA project makes available all content in this package
+        ("Content"). Unless otherwise indicated, the Content is provided to you
+        under the terms and conditions of the Mozilla Public License Version 2.0
+        ("MPL"). A copy of the MPL is available at
+        http://www.mozilla.org/MPL/2.0/.
+      </p>
 
-<body>
+      <p>
+        The openLCA project is maintained and coordinated by
+        <a href="www.greendelta.com">GreenDelta</a>. If you did not receive this
+        Content directly from the openLCA project, the Content is being
+        redistributed by another party ("Redistributor") and different terms and
+        conditions may apply to your use of any object code in the Content.
+        Check the Redistributor's license that was provided with the Content. If
+        no such license exists, contact the Redistributor. Unless otherwise
+        indicated below, the terms and conditions of the MPL still apply to any
+        source code in the Content and such source code may be obtained at
+        <a href="https://github.com/GreenDelta/olca-app"
+          >https://github.com/GreenDelta/olca-app</a
+        >
+        and
+        <a href="https://github.com/GreenDelta/olca-modules"
+          >https://github.com/GreenDelta/olca-modules</a
+        >.
+      </p>
 
-  <h1>License</h1>
+      <h1>Credits</h1>
 
-  <p>
-    The openLCA project makes available all content in this package
-    ("Content"). Unless otherwise indicated, the Content is provided
-    to you under the terms and conditions of the Mozilla Public License
-    Version 2.0 ("MPL"). A copy of the MPL is available at
-    http://www.mozilla.org/MPL/2.0/.
-  </p>
+      #{credits}#
+    </div>
+  </body>
+  <script>
+    attachHandlers();
+    function attachHandlers() {
+      const allActionNodes = Array.from(
+        document.querySelectorAll("[data-action-id]")
+      );
 
-  <p>
-    The openLCA project is maintained and coordinated by
-    <a href="www.greendelta.com">GreenDelta</a>. If you did not receive this
-    Content directly from the openLCA project, the Content is being
-    redistributed by another party ("Redistributor") and different terms and
-    conditions may apply to your use of any object code in the Content. Check
-    the Redistributor's license that was provided with the Content. If no such
-    license exists, contact the Redistributor. Unless otherwise indicated below,
-    the terms and conditions of the MPL still apply to any source code in the
-    Content and such source code may be obtained at
-    <a href="https://github.com/GreenDelta/olca-app">https://github.com/GreenDelta/olca-app</a>
-    and <a href="https://github.com/GreenDelta/olca-modules">https://github.com/GreenDelta/olca-modules</a>.
-  </p>
+      allActionNodes.forEach(function (node) {
+        const actionIdx = node.getAttribute("data-action-id");
+        node.addEventListener("click", function () {
+          const licenceDetailsNode = document.querySelector(
+            `[data-description="licence-content"][data-id="${actionIdx}"]`
+          );
+          if (!licenceDetailsNode) return;
 
-  <h1>Credits</h1>
-
-  {credits}
-
-</body>
-
+          if (node.innerHTML.trim().match("show licence")) {
+            node.innerHTML = "hide licence";
+            licenceDetailsNode.classList.remove("hide");
+          } else if (node.innerHTML.trim().match("hide licence")) {
+            node.innerHTML = "show licence";
+            licenceDetailsNode.classList.add("hide");
+          }
+        });
+      });
+    }
+  </script>
 </html>

--- a/olca-app-build/credits/credits-gen.js
+++ b/olca-app-build/credits/credits-gen.js
@@ -1,0 +1,101 @@
+const fs = require('fs/promises');
+const path = require('path');
+const http = require('http');
+const https = require('https');
+const creditsJsonPath = path.join(__dirname, 'credits.json');
+const cacheDirPath = path.join(__dirname, 'cache');
+const aboutTemplatePath = path.join(__dirname, 'about_template.html');
+const aboutHtmlPath = path.join(__dirname, 'about.html');
+
+/** Used to generate a normalised name for license cache file */
+function cacheFilename(projectName) {
+  return `${projectName.split(' ').join('_')}_license.txt`;
+}
+
+/** Fetches a license from url and returns the text */
+function fetchLicense(url) {
+  function makeRequest(url, resolve, reject) {
+    const requestClient = url.startsWith('http://') ? http : https;
+    requestClient.get(url, (resp) => {
+      if(resp.statusCode === 301 || resp.statusCode === 302) {
+        return makeRequest(resp.headers.location, resolve, reject)
+      } else {
+        let data = '';
+        resp.on('data', (chunk) => data += chunk);
+        resp.on('end', () => resolve(data));
+      }
+    }).on("error", (err) => reject(err));
+  }
+
+  return new Promise((resolve, reject) => makeRequest(url, resolve, reject));
+}
+
+/** Generates a file under cache directory containing the license text */
+async function cacheLicense(licenseFilename, licenseText) {
+  const licenseCachePath = path.join(cacheDirPath, licenseFilename);
+  return await fs.writeFile(licenseCachePath, licenseText);
+}
+
+/** Fetches license from cache if available otherwise retrieves it from internet and caches it */
+async function getLicenseText(credit) {
+  const { project, licenseUrl } = credit;
+  const cacheFile = cacheFilename(project);
+  const licenseCachePath = path.join(cacheDirPath, cacheFile);
+  try {
+    return await fs.readFile(licenseCachePath);
+  } catch(error) {
+    const licenseTxt = await fetchLicense(licenseUrl);
+    await cacheLicense(cacheFile, licenseTxt);
+    return licenseTxt;
+  }
+}
+
+/** Generates html block that also contains the license text */
+function generateHtmlForCredit(credit, licenseTxt) {
+  return `
+    <div style='width: 100%; margin-bottom: 10px;'>
+      <div class='block'>
+        <div class='mr-pd'>
+          <span>
+            ${credit.project}
+            (licensed under <a target="_blank" href="${credit.licenseUrl}">${credit.license}</a>)
+          </span>
+        </div>
+        <div style='display: flex; flex-direction: row;'>
+          <div class='mr-pd pointer'>
+            <span data-action-id='${credit.project}'>
+              show licence
+            </span>
+          </div>
+          <div class='mr-pd'>
+            <a target='_blank' href='${credit.projectUrl}'>homepage</a>
+          </div>
+        </div>
+      </div>
+      <div data-description='licence-content' data-id='${credit.project}' class='licence-details hide'>
+        <div>
+          <pre style='word-wrap: break-word; white-space: pre-wrap;'>${licenseTxt}</pre>
+        </div>
+      </div>
+    </div>
+  `
+}
+
+/** Injects the html code generated from `generateHtmlForCredit` in template file and writes it */
+async function generateAboutHtmlWithLicenseText(licenseHtml) {
+  const templateHtml = await fs.readFile(aboutTemplatePath, 'utf8');
+  const aboutHtml = templateHtml.replace('#{credits}#', licenseHtml);
+  await fs.writeFile(aboutHtmlPath, aboutHtml);
+}
+
+// Main function that reads credits from json and generates an html file for it
+(async () => {
+  const { credits } = JSON.parse(await fs.readFile(creditsJsonPath, 'utf8'));
+  await fs.mkdir(cacheDirPath).catch(() => { /* Ignore */ })
+  let licenseHtml = '';
+  for(const credit of credits) {
+    const licenseTxt = await getLicenseText(credit);
+    licenseHtml += generateHtmlForCredit(credit, licenseTxt);
+  }
+  await generateAboutHtmlWithLicenseText(licenseHtml);
+})();


### PR DESCRIPTION
This PR introduces a JS based credits file generator that retrieves a copy of license for each credit url and generates an html block that is later injected into the template.

To generate a template file all we need to do is run - `node credits-gen.js` from credits directory.