### PR TITLE
Fix text overlap on welcome page

### DIFF
--- a/olca-app-html/src/home/home.css
+++ b/olca-app-html/src/home/home.css
@@ -121,9 +121,10 @@ body {
 }
 
 .section {
-    width: 100%;
     height: calc(100vh - 186px);
     display: flex;
+    margin-left: 25px;
+    margin-right: 25px;
 }
 
 .left-section {
@@ -134,7 +135,6 @@ body {
 .nav-container {
     width: 100%;
     height: 100%;
-    padding-left: 25px;
     display: flex;
     align-content: center;
     align-items: center;
@@ -194,12 +194,10 @@ body {
 }
 
 .right-section-container {
-    width: calc(100% - 25px);
     height: 100%;
     display: flex;
     align-content: center;
     align-items: center;
-    padding-right: 25px;
 }
 
 .content-box {
@@ -252,7 +250,7 @@ body {
 @media (max-width: 768px) {
     .navigation {
         flex-direction: column;
-        gap: 10px
+        gap: 10px;
     }
 
     .nav-info {
@@ -357,12 +355,12 @@ body {
     }
 }
 
-@media (max-height: 700px){
-    .footer{
-        margin-top: 20px
+@media (max-height: 700px) {
+    .footer {
+        margin-top: 20px;
     }
 
-    .header{
+    .header {
         margin-bottom: 20px;
     }
 }


### PR DESCRIPTION
**Problem**
The welcome HTML page had text overlapping in smaller screen size. This was also evident when resizing the OpenLCA app window.

**Solution**
Updated the home.css by removing the padding from child section and adding margin to the parent section.

| Before | After |
| ------------- | ------------- |
| <img width="782" alt="Before" src="https://github.com/GreenDelta/olca-app/assets/27406822/ba26088c-d2aa-4b52-96ab-6ad0e0c0641b">  | <img width="781" alt="after" src="https://github.com/GreenDelta/olca-app/assets/27406822/46f5f447-18a4-4148-b0d2-13e4401024b8"> |


