### PR TITLE
Remove extension from the filename when saving a file as it duplicate…

### DIFF
--- a/olca-app/src/org/openlca/app/components/FileChooser.java
+++ b/olca-app/src/org/openlca/app/components/FileChooser.java
@@ -5,6 +5,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
+import org.apache.commons.io.FilenameUtils;
 import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.DirectoryDialog;
@@ -50,11 +51,12 @@ public class FileChooser {
 		dialog.setText(title == null ? M.Save : title);
 
 		if (defaultName != null) {
-			dialog.setFileName(defaultName);
-			var parts = defaultName.split("\\.");
-			if (parts.length > 1) {
-				var ext = parts[parts.length - 1];
+			var ext = FilenameUtils.getExtension(defaultName);
+			if (!Strings.nullOrEmpty(ext)) {
+				dialog.setFileName(FilenameUtils.getBaseName(defaultName));
 				dialog.setFilterExtensions(new String[]{"*." + ext});
+			} else {
+				dialog.setFileName(defaultName);
 			}
 		}
 


### PR DESCRIPTION
…s it on macOS.
![image](https://github.com/user-attachments/assets/9b38835d-c027-475e-8cdd-3e661661a4a6)
