### PR TITLE
Adding new nodes to the soda4LCA list

### DIFF
--- a/olca-app/src/org/openlca/app/tools/soda/soda-nodes.json
+++ b/olca-app/src/org/openlca/app/tools/soda/soda-nodes.json
@@ -113,5 +113,10 @@
     "name": "EF Small Data Provider",
     "url": "https://eplca.jrc.ec.europa.eu/EF-SDP/",
     "hasEPDs": false
+  },
+  {
+    "name": "Umweltbundesamt Probas2",
+    "url": "https://data.probas.umweltbundesamt.de/",
+    "hasEPDs": false
   }
 ]


### PR DESCRIPTION
Adding "EF Representative Products", "EF Small Data Provider", "Umweltbundesamt Probas2".

Renaming "Small Data Providers Database" into "ILCD-EL Small Data Providers Database" so that it is clear that this is the old EU small data provider node with ILCD-EL compliance and there is a newer EU small data provider node with EF compliance.