### PR TITLE
new URL() is deprecated, use new URI().toURL() instead

### DIFF
--- a/olca-app/src/org/openlca/app/preferences/LibDownload.java
+++ b/olca-app/src/org/openlca/app/preferences/LibDownload.java
@@ -1,16 +1,17 @@
 package org.openlca.app.preferences;
 
-import org.openlca.nativelib.Module;
-import org.openlca.nativelib.NativeLib;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.File;
 import java.io.IOException;
+import java.net.URI;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
 import java.util.zip.ZipFile;
+
+import org.openlca.nativelib.Module;
+import org.openlca.nativelib.NativeLib;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A utility class for downloading the native libraries of a module to a given
@@ -64,7 +65,7 @@ public class LibDownload {
 
 			var path = getUrl();
 			log.info("fetch jar from {}", path);
-			URL url = new URL(path);
+			URL url = new URI(path).toURL();
 
 			// download the jar/zip into a temporary file
 			var zip = Files.createTempFile(

--- a/olca-app/src/org/openlca/app/tools/soda/LoginDialog.java
+++ b/olca-app/src/org/openlca/app/tools/soda/LoginDialog.java
@@ -1,7 +1,8 @@
 package org.openlca.app.tools.soda;
 
 import java.net.MalformedURLException;
-import java.net.URL;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.Optional;
 
 import org.eclipse.swt.SWT;
@@ -127,8 +128,8 @@ class LoginDialog extends FormDialog {
 			if (!url.startsWith("http://") && !url.startsWith("https://"))
 				return M.UrlShouldStartWithHttp;
 			try {
-				new URL(url);
-			} catch (MalformedURLException e) {
+				new URI(url).toURL();
+			} catch (MalformedURLException | URISyntaxException e) {
 				return M.InvalidUrl + " - " + e.getMessage();
 			}
 


### PR DESCRIPTION
Same as previous, one warning remaining but that is a Path url, so needs different fix.