### PR TITLE
Fix windows toolbar search height

### DIFF
--- a/olca-app/plugin.xml
+++ b/olca-app/plugin.xml
@@ -495,7 +495,7 @@
 			point="org.eclipse.ui.commands">
 		<command
 				id="org.openlca.app.search.toolbar.spacer"
-				name="-">
+				name="&#8203;">
 		</command>
 	</extension>
 
@@ -505,9 +505,17 @@
 				locationURI="toolbar:org.eclipse.ui.trim.command2">
 			<toolbar
 					id="olca-app.search.toolbar">
+				<!--
+					Workaround for search toolbar spacing issue on Windows at high zoom levels (>200%).
+					See: https://bugs.eclipse.org/bugs/show_bug.cgi?id=465732#c5
+					
+					The fix is to add a HandledToolItem (via command) as the first element in the toolbar
+					before the ControlContribution. We use a zero-width space character (U+200B) as the
+					label to make it invisible while still fixing the alignment issue.
+				-->
 				<command
 						commandId="org.openlca.app.search.toolbar.spacer"
-						label="-"
+						label="&#8203;"
 						style="push"
 						tooltip="">
 				</command>


### PR DESCRIPTION
Fixes broken eclipse ui menu by adding a whitespaced label as per https://bugs.eclipse.org/bugs/show_bug.cgi?id=465732

Before:
<img width="2736" height="1824" alt="Screenshot (2)" src="https://github.com/user-attachments/assets/35c4c167-76f3-40c8-9954-1b711be94062" />

After:
<img width="2736" height="1824" alt="Screenshot (3)" src="https://github.com/user-attachments/assets/f4926e6d-7523-4477-961d-5c1cf6c79584" />
