### PR TITLE
Run gen-jython-bindings as part of npm build

### DIFF
--- a/gen-jython-bindings.js
+++ b/gen-jython-bindings.js
@@ -2,6 +2,7 @@
 // interpreter
 
 const fs = require('fs')
+const path = require('path')
 
 // checks if the given thing is a Java file
 let isFile = file =>
@@ -65,7 +66,7 @@ let scan = (folder, package, bindings) => {
   }
 }
 
-let generate = (folders, target) => {
+let generate = (baseFolder, folders, target) => {
   let bindings = {}
   for (let folder of folders) {
     scan(folder, '', bindings)
@@ -74,13 +75,15 @@ let generate = (folders, target) => {
     .sort()
     .map(clazz => `import ${bindings[clazz]} as ${clazz}\n`)
     .reduce((t, s) => t.concat(s))
-  let out = `olca-app/src/org/openlca/app/devtools/python/${target}`
+  let out = path.join(baseFolder, `olca-app/src/org/openlca/app/devtools/python/${target}`);
   let header = '# auto-generated bindings; do not edit them\n'
   fs.writeFileSync(out, header + text)
 }
 
 let main = () => {
-  let modPath = '../olca-modules'
+  let folder = path.dirname(process.argv[1]);
+  let parent = path.dirname(folder);
+  let modPath = path.join(parent, 'olca-modules');
   // duplicate class names are skipped, so
   // the order of the folders is important
   let modFolders = [
@@ -89,7 +92,7 @@ let main = () => {
     `${modPath}/olca-proto-io/src/main/java`,
     `${modPath}/olca-ipc/src/main/java`,
   ]
-  generate(modFolders, 'mod_bindings.py')
+  generate(folder, modFolders, 'mod_bindings.py')
 }
 
 main()

--- a/olca-app-html/package.json
+++ b/olca-app-html/package.json
@@ -4,7 +4,7 @@
   "description": "HTML pages of the openLCA application",
   "main": "index.js",
   "scripts": {
-    "prebuild": "python3 scripts/extract_completions.py",
+    "prebuild": "node ../gen-jython-bindings.js && python3 scripts/extract_completions.py",
     "build": "webpack --config webpack.config.js --mode=production",
     "predev": "python3 scripts/extract_completions.py",
     "dev": "webpack --config webpack.config.js --mode=development --watch",

--- a/prepare-release.py
+++ b/prepare-release.py
@@ -16,7 +16,6 @@ def main():
         call(["mvn", "package"], cwd="./olca-refdata")
         call(["npm", "install"], cwd="./olca-app-html")
         call(["npm", "run", "build"], cwd="./olca-app-html")
-        call(["node", "gen-jython-bindings.js"])
         call(["npm", "install"], cwd="./olca-app-build/credits")
         call(["node", "credits-gen.js"], cwd="./olca-app-build/credits")
     else:
@@ -25,7 +24,6 @@ def main():
         call("mvn.cmd package", cwd="./olca-refdata")
         call("npm.cmd install", cwd="./olca-app-html")
         call("npm.cmd run build", cwd="./olca-app-html")
-        call("node gen-jython-bindings.js")
         call("npm.cmd install", cwd="./olca-app-build/credits")
         call("node credits-gen.js", cwd="./olca-app-build/credits")
 


### PR DESCRIPTION
Commit 88f565e added the generated file mod_bindings.py to .gitignore. The file is produced by gen-jython-bindings.js, but in prepare-release.py the generation step was executed _after_ npm run build. This means the build may run against a stale or missing mod_bindings.py.

Following the build instructions in README.md from a freshly cloned repo also fails due to missing mod_bindings.py.

This PR addresses both problems by adding gen-python-bindings.js to the prebuild stage of the olca-app-html package. This also required modifying gen-jython-bindings.js so it can be run from a working directory other than its own.